### PR TITLE
Remove deprecated set-output command

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -32,7 +32,7 @@ runs:
           exit 1;
         fi
 
-        echo "::set-output name=version::${version}"
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
     - shell: bash
       run: |
         echo "Installing yq ${{ steps.version.outputs.version }}..."


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

fixes #32 